### PR TITLE
Created CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Paul-Austin-Oswego-CSC480-HCI521/triage


### PR DESCRIPTION
This file, along with configured repository/organization settings, requires that a member of the Triage team reviews any Pull Requests before they can be merged.